### PR TITLE
Wait for maker to load before applying scroll hooks

### DIFF
--- a/AI_MakerAdditions/Hooks.cs
+++ b/AI_MakerAdditions/Hooks.cs
@@ -124,7 +124,7 @@ namespace AI_MakerAdditions
         [HarmonyPostfix, HarmonyPatch(typeof(CustomCharaWindow), "Sort")]
         public static void CustomCharaWindow_Sort_ApplyScroll(CustomCharaWindow __instance, float __state)
         {
-            if (__state == 1f)
+            if (__state == 1f || !KKAPI.Maker.MakerAPI.InsideAndLoaded)
                 return;
             
             var scrollObj = __instance.transform.Find("Scroll View/Scrollbar Vertical");
@@ -143,7 +143,7 @@ namespace AI_MakerAdditions
         [HarmonyPostfix, HarmonyPatch(typeof(CustomClothesWindow), "Sort")]
         public static void CustomClothesWindow_Sort_ApplyScroll(CustomClothesWindow __instance, float __state)
         {
-            if (__state == 1f)
+            if (__state == 1f || !KKAPI.Maker.MakerAPI.InsideAndLoaded)
                 return;
             
             var scrollObj = __instance.transform.Find("Scroll View/Scrollbar Vertical");

--- a/HS2_MakerAdditions/Hooks.cs
+++ b/HS2_MakerAdditions/Hooks.cs
@@ -117,7 +117,6 @@ namespace HS2_MakerAdditions
         [HarmonyPrefix, HarmonyPatch(typeof(CustomCharaWindow), "Sort")]
         public static void CustomCharaWindow_Sort_SaveScroll(CustomCharaWindow __instance, out float __state)
         {
-            HS2_MakerAdditions.Logger.LogInfo("Sorting: " + System.Environment.StackTrace);
             var scrollObj = __instance.transform.Find("Scroll View/Scrollbar Vertical");
             __state = scrollObj.GetComponent<Scrollbar>().value;
         }
@@ -144,7 +143,7 @@ namespace HS2_MakerAdditions
         [HarmonyPostfix, HarmonyPatch(typeof(CustomClothesWindow), "Sort")]
         public static void CustomClothesWindow_Sort_ApplyScroll(CustomClothesWindow __instance, float __state)
         {
-            if (__state == 1f)
+            if (__state == 1f || !KKAPI.Maker.MakerAPI.InsideAndLoaded)
                 return;
             
             var scrollObj = __instance.transform.Find("Scroll View/Scrollbar Vertical");

--- a/HS2_MakerAdditions/Hooks.cs
+++ b/HS2_MakerAdditions/Hooks.cs
@@ -117,6 +117,7 @@ namespace HS2_MakerAdditions
         [HarmonyPrefix, HarmonyPatch(typeof(CustomCharaWindow), "Sort")]
         public static void CustomCharaWindow_Sort_SaveScroll(CustomCharaWindow __instance, out float __state)
         {
+            HS2_MakerAdditions.Logger.LogInfo("Sorting: " + System.Environment.StackTrace);
             var scrollObj = __instance.transform.Find("Scroll View/Scrollbar Vertical");
             __state = scrollObj.GetComponent<Scrollbar>().value;
         }
@@ -124,7 +125,7 @@ namespace HS2_MakerAdditions
         [HarmonyPostfix, HarmonyPatch(typeof(CustomCharaWindow), "Sort")]
         public static void CustomCharaWindow_Sort_ApplyScroll(CustomCharaWindow __instance, float __state)
         {
-            if (__state == 1f)
+            if (__state == 1f || !KKAPI.Maker.MakerAPI.InsideAndLoaded)
                 return;
             
             var scrollObj = __instance.transform.Find("Scroll View/Scrollbar Vertical");


### PR DESCRIPTION
I adore this functionality but it always loading to the bottom first time was driving me bonkers.

Since for some random reason Illusion set the scrollbar to go bottom-up...but sort top-down. This means during startup we need to scroll to top...which this stops causing it to load into a default state of all at the bottom.

A simple wait for maker to load fixes this.